### PR TITLE
update distributionUrl in gradle properties

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-4.0-20170417000025+0000-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip


### PR DESCRIPTION
is needed to work correctly with Android Studio 3.0 Canary 4